### PR TITLE
fix(create): honour OnConflict.Where in MERGE statements

### DIFF
--- a/create.go
+++ b/create.go
@@ -257,7 +257,19 @@ func MergeCreate(db *gorm.DB, onConflict clause.OnConflict, values clause.Values
 	}
 
 	if len(onConflict.DoUpdates) > 0 {
-		db.Statement.WriteString(" WHEN MATCHED THEN UPDATE SET ")
+		db.Statement.WriteString(" WHEN MATCHED")
+
+		// OnConflict.Where maps to Snowflake's optional MERGE update predicate:
+		// WHEN MATCHED AND <condition> THEN UPDATE. It is wrapped in parentheses
+		// so that a condition containing OR cannot bind loosely against the
+		// implicit AND and silently widen the set of updated rows.
+		if len(onConflict.Where.Exprs) > 0 {
+			db.Statement.WriteString(" AND (")
+			onConflict.Where.Build(db.Statement)
+			db.Statement.WriteByte(')')
+		}
+
+		db.Statement.WriteString(" THEN UPDATE SET ")
 		onConflict.DoUpdates.Build(db.Statement)
 	}
 

--- a/create_test.go
+++ b/create_test.go
@@ -1098,8 +1098,8 @@ func TestMergeCreateConditionalUpdate(t *testing.T) {
 
 		sql := stmt.Statement.SQL.String()
 
-		if !strings.Contains(sql, "WHEN MATCHED AND") {
-			t.Errorf("expected conditional WHEN MATCHED AND, got: %s", sql)
+		if !strings.Contains(sql, "WHEN MATCHED AND (") {
+			t.Errorf("expected conditional WHEN MATCHED AND ( with parentheses, got: %s", sql)
 		}
 		if !strings.Contains(sql, "EXCLUDED.age > test_models.age") {
 			t.Errorf("expected the Where condition in the SQL, got: %s", sql)

--- a/create_test.go
+++ b/create_test.go
@@ -1057,3 +1057,73 @@ func (w *clauseWriter) WriteByte(b byte) error {
 func (w *clauseWriter) WriteString(s string) (int, error) {
 	return w.Builder.WriteString(s)
 }
+
+// TestMergeCreateConditionalUpdate covers clause.OnConflict.Where, which maps to
+// Snowflake's `WHEN MATCHED AND <condition> THEN UPDATE`. Without it a caller
+// expressing a conditional upsert (e.g. "only apply if the incoming timestamp is
+// newer") silently gets an unconditional update, because the Where clause is
+// dropped rather than rejected.
+func TestMergeCreateConditionalUpdate(t *testing.T) {
+	newStmt := func(t *testing.T) *gorm.DB {
+		t.Helper()
+		db := setupMockDBWithConfig(t, true, true)
+		stmt := db.Session(&gorm.Session{DryRun: true}).Model(&TestModel{})
+		if err := stmt.Statement.Parse(&TestModel{}); err != nil {
+			t.Fatalf("Failed to parse model: %v", err)
+		}
+		stmt.Statement.SQL.Reset()
+		stmt.Statement.Vars = nil
+		return stmt
+	}
+
+	values := clause.Values{
+		Columns: []clause.Column{{Name: "name"}, {Name: "age"}, {Name: "id"}},
+		Values:  [][]interface{}{{"John", 25, uint(1)}},
+	}
+
+	doUpdates := clause.Assignments(map[string]interface{}{
+		"name": clause.Column{Name: "name"},
+		"age":  clause.Column{Name: "age"},
+	})
+
+	t.Run("emits WHEN MATCHED AND when Where is set", func(t *testing.T) {
+		stmt := newStmt(t)
+
+		MergeCreate(stmt, clause.OnConflict{
+			DoUpdates: doUpdates,
+			Where: clause.Where{Exprs: []clause.Expression{
+				clause.Expr{SQL: "EXCLUDED.age > test_models.age"},
+			}},
+		}, values)
+
+		sql := stmt.Statement.SQL.String()
+
+		if !strings.Contains(sql, "WHEN MATCHED AND") {
+			t.Errorf("expected conditional WHEN MATCHED AND, got: %s", sql)
+		}
+		if !strings.Contains(sql, "EXCLUDED.age > test_models.age") {
+			t.Errorf("expected the Where condition in the SQL, got: %s", sql)
+		}
+		if !strings.Contains(sql, "THEN UPDATE SET") {
+			t.Errorf("expected UPDATE clause, got: %s", sql)
+		}
+		if !strings.Contains(sql, "WHEN NOT MATCHED THEN INSERT") {
+			t.Errorf("expected INSERT clause, got: %s", sql)
+		}
+	})
+
+	t.Run("stays unconditional when Where is empty", func(t *testing.T) {
+		stmt := newStmt(t)
+
+		MergeCreate(stmt, clause.OnConflict{DoUpdates: doUpdates}, values)
+
+		sql := stmt.Statement.SQL.String()
+
+		if !strings.Contains(sql, "WHEN MATCHED THEN UPDATE SET") {
+			t.Errorf("expected unconditional WHEN MATCHED, got: %s", sql)
+		}
+		if strings.Contains(sql, "WHEN MATCHED AND") {
+			t.Errorf("did not expect a condition without Where, got: %s", sql)
+		}
+	})
+}


### PR DESCRIPTION
### Problem

`MergeCreate` builds the MERGE update branch from `clause.OnConflict.DoUpdates` but never reads `clause.OnConflict.Where`. A conditional upsert like this:

```go
db.Clauses(clause.OnConflict{
    DoUpdates: clause.AssignmentColumns(cols),
    Where: clause.Where{Exprs: []clause.Expression{clause.Expr{
        SQL: `"JOBS"."STATUS_TIMESTAMP" IS NULL OR excluded."STATUS_TIMESTAMP" > "JOBS"."STATUS_TIMESTAMP"`,
    }}},
}).Create(&row)
```

compiles, runs, and returns no error — but the condition is dropped:

```sql
-- before
... ON "JOBS"."ID" = EXCLUDED."ID" WHEN MATCHED THEN UPDATE SET ...
```

The silence is the dangerous part. This pattern is the standard guard against out-of-order or replayed messages ("only apply this row if its timestamp is newer than the stored one"). Callers relying on it for correctness get no guard at all, and nothing surfaces the fact — the data quietly ends up wrong when messages arrive out of order.

### Fix

Emit the predicate as Snowflake's optional MERGE update condition:

```sql
-- after
... ON "JOBS"."ID" = EXCLUDED."ID"
WHEN MATCHED AND ("JOBS"."STATUS_TIMESTAMP" IS NULL
                  OR excluded."STATUS_TIMESTAMP" > "JOBS"."STATUS_TIMESTAMP")
THEN UPDATE SET ...
```

The condition is wrapped in parentheses so that a `Where` containing `OR` cannot bind loosely against the implicit `AND` and widen the set of updated rows.

Behaviour is unchanged when `Where` is empty, so this is backwards compatible.

### Tests

Added `TestMergeCreateConditionalUpdate` with two subtests — one asserting the condition is emitted, one asserting the statement stays unconditional when `Where` is empty. The first fails on `main` and passes with this change.

`make test` passes; `go vet ./...` is clean.

Additionally verified end-to-end against a real Snowflake account: the generated MERGE executes, and a four-phase test (insert / newer applied / older skipped / equal skipped) passes. The last two phases only pass if the guard actually reaches the database.